### PR TITLE
Disable Interactive Mode 

### DIFF
--- a/scripts/waggle-service.py
+++ b/scripts/waggle-service.py
@@ -10,6 +10,7 @@ from tabulate import tabulate
 #    print "You need to have root privileges to start a service, exited from services." 
 
 
+
 class Service:
     
     service_commands = ['start', 'stop', 'restart', 'status']

--- a/scripts/waggle-service.py
+++ b/scripts/waggle-service.py
@@ -365,23 +365,24 @@ if __name__ == "__main__":
         
         sys.exit(1)
         
-        
+    print "\nList of services: \n"
+    upstart.overview(interactive=True)        
     
             
-    try:
-        while True:
+   # try:
+    #    while True:
             
-            print "\nList of services: \n"
-            upstart.overview(interactive=True)
+     #       print "\nList of services: \n"
+      #      upstart.overview(interactive=True)
             
             
-            command = raw_input('\nMain menu\nEnter your command: ')
+       #     command = raw_input('\nMain menu\nEnter your command: ')
             #print "got '%s' \n" % (command)
-            print ''
-            if (not command):
-                continue
+        #    print ''
+         #   if (not command):
+          #      continue
                 
-            upstart.execute(re.split(r"\s+", command), interactive=True) 
+           # upstart.execute(re.split(r"\s+", command), interactive=True) 
             
             
             # if (command == "l"):
@@ -407,7 +408,7 @@ if __name__ == "__main__":
                     
             
         
-    except KeyboardInterrupt:
-        print "exiting..."
-    except Exception as e:
-        print "error: "+str(e)
+   # except KeyboardInterrupt:
+    #    print "exiting..."
+   # except Exception as e:
+    #    print "error: "+str(e)


### PR DESCRIPTION
Disabled the interactive feature of the 'waggle-service' command so it now behaves the same as 'waggle-service list'
